### PR TITLE
Decouple controllers from FastAPI

### DIFF
--- a/app/application/controllers/user_controller.py
+++ b/app/application/controllers/user_controller.py
@@ -2,9 +2,8 @@
 
 from uuid import UUID
 
-from fastapi import HTTPException, status
-
 from app.adapters.specifications.user_specs.user_by_id import UserById
+from app.application.exceptions import NotFoundError
 from app.application.use_cases.user.create_user import CreateUserUseCase
 from app.application.use_cases.user.delete_user import DeleteUserUseCase
 from app.application.use_cases.user.get_user import GetUserUseCase
@@ -55,10 +54,10 @@ class UserController:
             deactivate=deactivate,
         )
         if updated is None:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+            raise NotFoundError("User not found")
         return updated
 
     async def delete_user(self, user_id: UUID) -> None:
         ok = await self.delete_uc.execute(user_id)
         if not ok:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+            raise NotFoundError("User not found")

--- a/app/application/exceptions.py
+++ b/app/application/exceptions.py
@@ -1,0 +1,22 @@
+class ApplicationError(Exception):
+    """Base class for application layer errors."""
+
+
+class UnauthorizedError(ApplicationError):
+    """Raised when authentication fails."""
+
+
+class BadRequestError(ApplicationError):
+    """Raised when provided data is invalid."""
+
+
+class NotFoundError(ApplicationError):
+    """Raised when an entity is not found."""
+
+
+class TooManyRequestsError(ApplicationError):
+    """Raised when too many requests are made."""
+
+
+class InternalError(ApplicationError):
+    """Raised for unexpected internal errors."""

--- a/app/presentation/routers/auth.py
+++ b/app/presentation/routers/auth.py
@@ -3,10 +3,16 @@
 from typing import Annotated, Any
 
 from dishka.integrations.fastapi import DishkaRoute, FromDishka
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 from app.application.controllers.auth_controller import AuthController
+from app.application.exceptions import (
+    BadRequestError,
+    InternalError,
+    TooManyRequestsError,
+    UnauthorizedError,
+)
 from app.domain.ports.token_service import TokenServicePort
 from app.presentation.middleware.auth import (
     get_current_user_dishka,
@@ -34,10 +40,17 @@ async def login(
         credentials: Annotated[HTTPBasicCredentials, Depends(security)]
 ):
     """Вход в систему"""
-    return await controller.login(
-        username=credentials.username,
-        password=credentials.password
-    )
+    try:
+        return await controller.login(
+            username=credentials.username,
+            password=credentials.password,
+        )
+    except UnauthorizedError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(ex),
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from ex
 
 
 @router.post("/logout", response_model=MessageResponse)
@@ -59,7 +72,14 @@ async def refresh_token(
         controller: FromDishka[AuthController]
 ):
     """Обновить access token"""
-    return await controller.refresh(request.refresh_token)
+    try:
+        return await controller.refresh(request.refresh_token)
+    except UnauthorizedError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(ex),
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from ex
 
 
 @router.get("/me", response_model=CurrentUser)
@@ -82,10 +102,16 @@ async def register(
     controller: FromDishka[AuthController]
 ):
     """Регистрация нового пользователя"""
-    return await controller.register(
-        username=request.username,
-        password=request.password
-    )
+    try:
+        return await controller.register(
+            username=request.username,
+            password=request.password,
+        )
+    except BadRequestError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(ex),
+        ) from ex
 
 
 @router.post("/setup-pin", response_model=dict[str, Any])
@@ -98,12 +124,18 @@ async def setup_pin(
     """Установить PIN для мобильного устройства"""
     current_user = await get_current_user_dishka(request, token_service)
 
-    return await controller.setup_pin(
-        user_id=current_user["user_id"],
-        pin_code=pin_request.pin_code,
-        device_id=pin_request.device_id,
-        device_name=pin_request.device_name
-    )
+    try:
+        return await controller.setup_pin(
+            user_id=current_user["user_id"],
+            pin_code=pin_request.pin_code,
+            device_id=pin_request.device_id,
+            device_name=pin_request.device_name,
+        )
+    except BadRequestError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(ex),
+        ) from ex
 
 
 @router.post("/pin-login", response_model=TokenResponse)
@@ -112,11 +144,22 @@ async def pin_login(
         controller: FromDishka[AuthController]
 ):
     """Вход по PIN-коду"""
-    return await controller.pin_login(
-        pin_code=request.pin_code,
-        device_id=request.device_id,
-        refresh_token=request.refresh_token
-    )
+    try:
+        return await controller.pin_login(
+            pin_code=request.pin_code,
+            device_id=request.device_id,
+            refresh_token=request.refresh_token,
+        )
+    except UnauthorizedError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(ex),
+        ) from ex
+    except TooManyRequestsError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=str(ex),
+        ) from ex
 
 # app/presentation/routers/auth.py
 
@@ -128,7 +171,13 @@ async def list_devices(
 ):
     """Получить список устройств пользователя"""
     current_user = await get_current_user_dishka(request, token_service)
-    return await controller.list_devices(current_user["user_id"])
+    try:
+        return await controller.list_devices(current_user["user_id"])
+    except InternalError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(ex),
+        ) from ex
 
 @router.delete("/devices/{device_id}")
 async def revoke_device(
@@ -139,5 +188,11 @@ async def revoke_device(
 ):
     """Отозвать доступ устройства"""
     current_user = await get_current_user_dishka(request, token_service)
-    await controller.revoke_device(current_user["user_id"], device_id)
+    try:
+        await controller.revoke_device(current_user["user_id"], device_id)
+    except InternalError as ex:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(ex),
+        ) from ex
     return {"message": "Device revoked successfully"}

--- a/tests/test_auth_controller.py
+++ b/tests/test_auth_controller.py
@@ -1,7 +1,10 @@
 import pytest
-from fastapi import HTTPException
 
 from app.application.controllers.auth_controller import AuthController
+from app.application.exceptions import (
+    BadRequestError,
+    UnauthorizedError,
+)
 from app.domain.entities.user import UserRole
 
 
@@ -49,18 +52,18 @@ controller = AuthController(DummyLogin(), DummyLogout(), DummyRefresh(), DummyRe
 @pytest.mark.asyncio
 async def test_login_ok_and_fail():
     assert await controller.login('u', 'ok') == {'token': 't'}
-    with pytest.raises(HTTPException):
+    with pytest.raises(UnauthorizedError):
         await controller.login('u', 'bad')
 
 
 @pytest.mark.asyncio
 async def test_refresh_and_register():
     assert await controller.refresh('r') == {'token': 'new'}
-    with pytest.raises(HTTPException):
+    with pytest.raises(UnauthorizedError):
         await controller.refresh('bad')
     resp = await controller.register('new', 'p')
     assert resp['username'] == 'new'
-    with pytest.raises(HTTPException):
+    with pytest.raises(BadRequestError):
         await controller.register('old', 'p')
 
 

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -1,11 +1,12 @@
-import pytest
 import fakeredis.aioredis as fakeredis
+import pytest
+from redis.asyncio import Redis
 
+from app.adapters.specifications.user_specs.user_by_name import UserByName
 from app.application.use_cases.auth.login import LoginUseCase
 from app.application.use_cases.auth.refresh import RefreshTokenUseCase
 from app.application.use_cases.auth.register import RegisterUseCase
 from app.application.use_cases.user.update_user import UpdateUserUseCase
-from app.adapters.specifications.user_specs.user_by_name import UserByName
 from app.config.settings import SecuritySettings
 from app.domain.entities.user import UserRole
 from app.infrastructure.services.password_service import PasswordServiceImpl

--- a/tests/test_user_controller.py
+++ b/tests/test_user_controller.py
@@ -1,8 +1,9 @@
-import pytest
-from fastapi import HTTPException
 from uuid import uuid4
 
+import pytest
+
 from app.application.controllers.user_controller import UserController
+from app.application.exceptions import NotFoundError
 from app.domain.entities.user import User, UserRole
 
 
@@ -42,8 +43,8 @@ async def test_user_controller_crud():
 async def test_update_delete_not_found():
     update_uc = DummyUC(None)
     ctrl = UserController(None, None, None, update_uc, DummyUC(False))
-    with pytest.raises(HTTPException):
+    with pytest.raises(NotFoundError):
         await ctrl.update_user(uuid4(), None, None, None)
-    with pytest.raises(HTTPException):
+    with pytest.raises(NotFoundError):
         await ctrl.delete_user(uuid4())
 


### PR DESCRIPTION
## Summary
- add application-layer exceptions
- refactor controllers to raise custom errors instead of `HTTPException`
- handle controller errors inside routers
- update tests for new exceptions

## Testing
- `ruff check app/application/controllers/auth_controller.py app/application/controllers/user_controller.py app/application/exceptions.py app/presentation/routers/auth.py app/presentation/routers/user.py tests/test_auth_controller.py tests/test_user_controller.py tests/test_use_cases.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840e4b1e8c0832096578577c40adaf4